### PR TITLE
Darwin blog fixes

### DIFF
--- a/_includes/all_categories.html
+++ b/_includes/all_categories.html
@@ -11,7 +11,7 @@ to the `site_categories` variable. -->
 {% assign cat_words = filtered_categories | split: ',' | sort %}
 
 <ul class="categories">
-  {% for item in (0..cat_words.size) %}{% unless forloop.last %}
+  {% for item in (1..cat_words.size) %}{% unless forloop.last %}
     {% capture this_word %}{{ cat_words[item] }}{% endcapture %}
     <li>
       <a href="{{ site.baseurl }}/blog/categories#{{ this_word | slugify }}" class="category">{{ this_word }}

--- a/_includes/all_tags.html
+++ b/_includes/all_tags.html
@@ -6,7 +6,7 @@ to the `site_tags` variable. -->
 {% assign tag_words = site_tags | split:',' | sort %}
 
 <ul class="tags">
-  {% for item in (0..site.tags.size) %}{% unless forloop.last %}
+  {% for item in (1..site.tags.size) %}{% unless forloop.last %}
     {% capture this_word %}{{ tag_words[item] }}{% endcapture %}
     <li>
       <a href="{{ site.baseurl }}/blog/tags#{{ this_word | slugify }}" class="tag">{{ this_word }}

--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -23,7 +23,7 @@
             <hr />
             <h3>Posts by Category</h3>
             <!-- This code uses the cat_words list from all_categories.html -->
-            {% for item in (0..cat_words.size) %}{% unless forloop.last %}
+            {% for item in (1..cat_words.size) %}{% unless forloop.last %}
               {% capture this_word %}{{ cat_words[item] }}{% endcapture %}
               <h4 id="{{ this_word | slugify }}">{{ this_word }}</h4>
               <ul class="posts-by-category">

--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -23,7 +23,7 @@
             <hr />
             <h3>Posts by Tag</h3>
             <!-- This code uses the tag_words list from all_tags.html -->
-            {% for item in (0..site.tags.size) %}{% unless forloop.last %}
+            {% for item in (1..site.tags.size) %}{% unless forloop.last %}
               {% capture this_word %}{{ tag_words[item] }}{% endcapture %}
               <h4 id="{{ this_word | slugify }}">{{ this_word }}</h4>
               <ul class="posts-by-tag">

--- a/_posts/blog/2017-04-28-doing-things-differently.md
+++ b/_posts/blog/2017-04-28-doing-things-differently.md
@@ -1,7 +1,7 @@
 ---
 title: Doing Things Differently
 author: Mike Hay
-category: Culture
+categories: Culture
 tags: methodology team
 ---
 


### PR DESCRIPTION
“category” and “categories” should be equivalent, but it’s causing
strange behavior. Need to look at this again probably, but for now this
fixes it.