### PR TITLE
Add Brandon's author info and fix category list in blog post

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -65,3 +65,9 @@ Karl Smith:
 
 Fred Medlin:
   title: Android Engineer
+
+# Design
+
+Brandon Houlihan:
+  title: Design Manager
+  avatar: kets/ronburgundy.png

--- a/_posts/blog/2017-05-15-how-to-structure-product-feedback.md
+++ b/_posts/blog/2017-05-15-how-to-structure-product-feedback.md
@@ -1,7 +1,7 @@
 ---
 title: How to Structure Product Feedback
 author: Brandon Houlihan
-categories: Product, Culture
+categories: Product Culture
 tags: feedback team design
 ---
 


### PR DESCRIPTION
Upload contains the edits from the last pull request. We can figure out how to properly do this at some other point. I just want to get this up without spending too much time.